### PR TITLE
Bind rubocop version to 0.47.1

### DIFF
--- a/unasukecop.gemspec
+++ b/unasukecop.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop"
+  spec.add_dependency "rubocop", '0.47.1'
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
if rubocop releases new version and contain new cops,
fail 'bundle exec rubocop' by new cops.